### PR TITLE
Wrap UnexpectedError.msg in assert.fail

### DIFF
--- a/test/unexpected-node-test-serialization-issue.spec.js
+++ b/test/unexpected-node-test-serialization-issue.spec.js
@@ -1,9 +1,14 @@
 import { describe, it } from "node:test";
+import assert from "node:assert";
 import expect from "unexpected";
 import unexpectedNodeTestSerializationIssue from "../lib/unexpected-node-test-serialization-issue.js";
 
 describe("unexpected-node-test-serialization-issue", () => {
   it("should be a function", () => {
-    expect(unexpectedNodeTestSerializationIssue, "to be a function");
+    try {
+      expect(unexpectedNodeTestSerializationIssue, "to be a function");
+    } catch (err) {
+      assert.fail(err.message);
+    }
   });
 });


### PR DESCRIPTION
This solves the formatting of the message, with other obvious drawbacks...